### PR TITLE
Enable UNISTD_H on non-Windows platforms

### DIFF
--- a/zconf.h
+++ b/zconf.h
@@ -8,6 +8,10 @@
 #ifndef ZCONF_H
 #define ZCONF_H
 
+#if !defined(WINDOWS) && !defined(WIN32)
+#define HAVE_UNISTD_H
+#endif
+
 /*
  * If you *really* need a unique prefix for all types and library functions,
  * compile with -DZ_PREFIX. The "standard" zlib should be compiled without it.


### PR DESCRIPTION
Since we don't run the configure script, we'll hard code this.