### PR TITLE
Add an include guard

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -3,6 +3,8 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#pragma once
+
 #ifdef _LARGEFILE64_SOURCE
 #  ifndef _LARGEFILE_SOURCE
 #    define _LARGEFILE_SOURCE 1


### PR DESCRIPTION
Without this include guard some of the lumped builds in Unity fail.