### PR TITLE
Consistently apply il2cpp_z_ prefix

### DIFF
--- a/gzread.c
+++ b/gzread.c
@@ -440,7 +440,7 @@ z_size_t ZEXPORT gzfread(buf, size, nitems, file)
 
 /* -- see zlib.h -- */
 #ifdef Z_PREFIX_SET
-#  undef z_gzgetc
+#  undef il2cpp_z_gzgetc
 #else
 #  undef gzgetc
 #endif

--- a/zconf.h
+++ b/zconf.h
@@ -20,6 +20,7 @@
  */
 #define Z_PREFIX 1
 #ifdef Z_PREFIX     /* may be set to #if 1 by ./configure */
+#  define Z_PREFIX_SET
 
 /* all linked symbols and init macros */
 #  define _dist_code            il2cpp_z__dist_code
@@ -48,6 +49,8 @@
 #  define deflateCopy           il2cpp_z_deflateCopy
 #  define deflateEnd            il2cpp_z_deflateEnd
 #  define deflateGetDictionary  il2cpp_z_deflateGetDictionary
+#  define deflateInit           il2cpp_z_deflateInit
+#  define deflateInit2          il2cpp_z_deflateInit2
 #  define deflateInit2_         il2cpp_z_deflateInit2_
 #  define deflateInit_          il2cpp_z_deflateInit_
 #  define deflateParams         il2cpp_z_deflateParams
@@ -76,6 +79,7 @@
 #    define gzflush               il2cpp_z_gzflush
 #    define gzfread               il2cpp_z_gzfread
 #    define gzfwrite              il2cpp_z_gzfwrite
+#    define gzgetc                il2cpp_z_gzgetc
 #    define gzgetc_               il2cpp_z_gzgetc_
 #    define gzgets                il2cpp_z_gzgets
 #    define gzoffset              il2cpp_z_gzoffset
@@ -102,12 +106,15 @@
 #  define inflate               il2cpp_z_inflate
 #  define inflateBack           il2cpp_z_inflateBack
 #  define inflateBackEnd        il2cpp_z_inflateBackEnd
+#  define inflateBackInit       il2cpp_z_inflateBackInit
 #  define inflateBackInit_      il2cpp_z_inflateBackInit_
 #  define inflateCodesUsed      il2cpp_z_inflateCodesUsed
 #  define inflateCopy           il2cpp_z_inflateCopy
 #  define inflateEnd            il2cpp_z_inflateEnd
 #  define inflateGetDictionary  il2cpp_z_inflateGetDictionary
 #  define inflateGetHeader      il2cpp_z_inflateGetHeader
+#  define inflateInit           il2cpp_z_inflateInit
+#  define inflateInit2          il2cpp_z_inflateInit2
 #  define inflateInit2_         il2cpp_z_inflateInit2_
 #  define inflateInit_          il2cpp_z_inflateInit_
 #  define inflateMark           il2cpp_z_inflateMark

--- a/zlib.h
+++ b/zlib.h
@@ -1776,17 +1776,17 @@ ZEXTERN int ZEXPORT inflateBackInit_ OF((z_streamp strm, int windowBits,
                                          const char *version,
                                          int stream_size));
 #ifdef Z_PREFIX_SET
-#  define z_deflateInit(strm, level) \
+#  define il2cpp_z_deflateInit(strm, level) \
           deflateInit_((strm), (level), ZLIB_VERSION, (int)sizeof(z_stream))
-#  define z_inflateInit(strm) \
+#  define il2cpp_z_inflateInit(strm) \
           inflateInit_((strm), ZLIB_VERSION, (int)sizeof(z_stream))
-#  define z_deflateInit2(strm, level, method, windowBits, memLevel, strategy) \
+#  define il2cpp_z_deflateInit2(strm, level, method, windowBits, memLevel, strategy) \
           deflateInit2_((strm),(level),(method),(windowBits),(memLevel),\
                         (strategy), ZLIB_VERSION, (int)sizeof(z_stream))
-#  define z_inflateInit2(strm, windowBits) \
+#  define il2cpp_z_inflateInit2(strm, windowBits) \
           inflateInit2_((strm), (windowBits), ZLIB_VERSION, \
                         (int)sizeof(z_stream))
-#  define z_inflateBackInit(strm, windowBits, window) \
+#  define il2cpp_z_inflateBackInit(strm, windowBits, window) \
           inflateBackInit_((strm), (windowBits), (window), \
                            ZLIB_VERSION, (int)sizeof(z_stream))
 #else
@@ -1821,8 +1821,8 @@ struct gzFile_s {
 };
 ZEXTERN int ZEXPORT gzgetc_ OF((gzFile file));  /* backward compatibility */
 #ifdef Z_PREFIX_SET
-#  undef z_gzgetc
-#  define z_gzgetc(g) \
+#  undef il2cpp_z_gzgetc
+#  define il2cpp_z_gzgetc(g) \
           ((g)->have ? ((g)->have--, (g)->pos++, *((g)->next)++) : (gzgetc)(g))
 #else
 #  define gzgetc(g) \
@@ -1846,12 +1846,12 @@ ZEXTERN int ZEXPORT gzgetc_ OF((gzFile file));  /* backward compatibility */
 
 #if !defined(ZLIB_INTERNAL) && defined(Z_WANT64)
 #  ifdef Z_PREFIX_SET
-#    define z_gzopen z_gzopen64
-#    define z_gzseek z_gzseek64
-#    define z_gztell z_gztell64
-#    define z_gzoffset z_gzoffset64
-#    define z_adler32_combine z_adler32_combine64
-#    define z_crc32_combine z_crc32_combine64
+#    define il2cpp_z_gzopen il2cpp_z_gzopen64
+#    define il2cpp_z_gzseek il2cpp_z_gzseek64
+#    define il2cpp_z_gztell il2cpp_z_gztell64
+#    define il2cpp_z_gzoffset il2cpp_z_gzoffset64
+#    define il2cpp_z_adler32_combine il2cpp_z_adler32_combine64
+#    define il2cpp_z_crc32_combine il2cpp_z_crc32_combine64
 #  else
 #    define gzopen gzopen64
 #    define gzseek gzseek64


### PR DESCRIPTION
This changes reverts https://github.com/Unity-Technologies/zlib/pull/2 and applies the `il2cpp_z_` prefix consistently everywhere the original `z_` prefixes were used. This allows additional code paths to work with additional defines that remap 32 bit to 64 bit versions.